### PR TITLE
[Feature] adding CustomTextField

### DIFF
--- a/FakeNFT/Helpers/Extensions/View+Extensions.swift
+++ b/FakeNFT/Helpers/Extensions/View+Extensions.swift
@@ -7,6 +7,9 @@
 import SwiftUI
 
 extension View {
+    
+    // MARK: - Text Styles
+    
     func appTextStyleBodyRegular(withColor color: Color = .appBlack) -> some View {
         self.modifier(AppTextStyleBodyRegular())
             .foregroundStyle(color)
@@ -45,5 +48,15 @@ extension View {
     func appTextStyleHeadline4(withColor color: Color = .appBlack) -> some View {
         self.modifier(AppTextStyleHeadline4())
             .foregroundStyle(color)
+    }
+    
+    // MARK: - TextField Styles
+    
+    func appTextFieldStyle(lineLimit: Int = 1) -> some View {
+        self.modifier(AppTextFieldStyle(lineLimit: lineLimit))
+    }
+    
+    func clearButton(on text: Binding<String>) -> some View {
+        self.modifier(AppTextFieldClearButtonStyle(text: text))
     }
 }

--- a/FakeNFT/Helpers/TextFieldStyle/AppTextFieldClearButtonStyle.swift
+++ b/FakeNFT/Helpers/TextFieldStyle/AppTextFieldClearButtonStyle.swift
@@ -1,0 +1,34 @@
+//
+//  AppTextFieldClearButtonStyle.swift
+//  FakeNFT
+//
+//  Created by Roman Romanov on 01.03.2025.
+//
+
+import SwiftUI
+
+struct AppTextFieldClearButtonStyle: ViewModifier {
+    
+    @Binding var text: String
+    @FocusState private var isFocused: Bool
+    
+    func body(content: Content) -> some View {
+        ZStack(alignment: .trailing) {
+            content
+                .focused($isFocused)
+                .padding(.trailing, 20)
+            if !text.isEmpty && isFocused {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "multiply.circle.fill")
+                }
+                .opacity(text.isEmpty ? 0 : 1)
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut, value: text)
+    }
+}

--- a/FakeNFT/Helpers/TextFieldStyle/AppTextFieldStyle.swift
+++ b/FakeNFT/Helpers/TextFieldStyle/AppTextFieldStyle.swift
@@ -1,0 +1,30 @@
+//
+//  AppTextFieldStyle.swift
+//  FakeNFT
+//
+//  Created by Roman Romanov on 01.03.2025.
+//
+
+import SwiftUI
+
+struct AppTextFieldStyle: ViewModifier {
+    
+    let lineLimit: Int
+    private let roundedRectangle = RoundedRectangle(cornerRadius: 16)
+    
+    func body(content: Content) -> some View {
+        content
+            .appTextStyleBodyRegular()
+            .lineLimit(lineLimit, reservesSpace: true)
+            .padding(.all, 11)
+            .padding(.horizontal, 5)
+            .background(.appLightGray)
+            .overlay(
+                roundedRectangle
+                    .stroke(.appLightGray, lineWidth: 1)
+            )
+            .clipShape(
+                roundedRectangle
+            )
+    }
+}

--- a/FakeNFT/UIElements/CustomTextField.swift
+++ b/FakeNFT/UIElements/CustomTextField.swift
@@ -1,0 +1,45 @@
+//
+//  CustomTextField.swift
+//  FakeNFT
+//
+//  Created by Roman Romanov on 01.03.2025.
+//
+
+import SwiftUI
+
+struct CustomTextField: View {
+    @Binding var text: String
+    let placeholder: LocalizedStringKey
+    let lineLimit: Int
+    
+    var body: some View {
+        TextField(
+            placeholder,
+            text: $text,
+            axis: lineLimit == 1
+                ? .horizontal
+                : .vertical
+        )
+        .clearButton(on: $text)
+        .appTextFieldStyle(lineLimit: lineLimit)
+    }
+}
+
+#Preview {
+    @Previewable @State var nameValue: String = ""
+    @Previewable @State var descriptionValue: String = ""
+    
+    VStack(spacing: 20) {
+        CustomTextField(
+            text: $nameValue,
+            placeholder: "Enter your name",
+            lineLimit: 1
+        )
+        
+        CustomTextField(
+            text: $descriptionValue,
+            placeholder: "Tell us about yourself",
+            lineLimit: 5
+        )
+    }
+}

--- a/FakeNFT/UIElements/CustomTextField.swift
+++ b/FakeNFT/UIElements/CustomTextField.swift
@@ -42,4 +42,5 @@ struct CustomTextField: View {
             lineLimit: 5
         )
     }
+    .padding()
 }


### PR DESCRIPTION
добавил кастомный TextField в возможностью настройки под вид TextArea и кнопкой очистки

есть совету просто в ините добавить, но это как-то криво работает


``` 
UITextField.appearance().clearButtonMode = .whileEditing
```

<img width="356" alt="Screenshot 2025-03-01 at 11 24 01" src="https://github.com/user-attachments/assets/3fd55162-7ac4-4a2f-8866-9a92bce98ab8" />

пример использования [тут](https://github.com/volk-r/FakeNFT/blob/rromanov/feature/module_2/FakeNFT/Presentation/Profile/Subviews/EditProfile/Components/EditableValue.swift#L17)

выглядит все это вместе вот так

<img width="1040" alt="Screenshot 2025-03-01 at 11 29 38" src="https://github.com/user-attachments/assets/ad784eb9-757b-478a-b6db-88bc73258249" />
<img width="1041" alt="Screenshot 2025-03-01 at 11 29 46" src="https://github.com/user-attachments/assets/0cdedf61-a913-4c91-a530-7e11e13fab41" />
